### PR TITLE
Support overriding remote timezone

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 venv
+.venv
 *.pyc
 .env
 .gitignore

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Set the settings as environment variables:
 * LOCAL_PASSWORD (str): CalDAV password.
 * REMOTE_USERNAME (str, optional): ICS host username.
 * REMOTE_PASSWORD (str, optional): ICS host password.
+* TIMEZONE (str, optional): Override events timezone. (Example timezones: Utc, Europe/Warsaw, Asia/Tokyo).
 * SYNC_EVERY (str): How often should the synchronisation occur? For example: 2 minutes, 1 hour. Synchronise once if empty.
 * DEBUG (bool, optional): Set to anything to print debugging messages. Please set this when reporting an error.
 * SYNC_ALL (bool, optional): If set, all events in the calendar will be synced. Otherwise, only the ones occuring in the future will be.
@@ -40,7 +41,8 @@ class and its `synchronise` method.
         local_password: str,
         remote_username: str = "",
         remote_password: str = "",
-        sync_all: bool = False
+        sync_all: bool = False,
+        timezone: str = "",
     )
 
     def ICSToCalDavSync.synchronise(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,15 @@
 arrow==1.3.0
-caldav==1.3.9
-certifi==2024.2.2
-charset-normalizer==3.3.2
-ics==0.7.2
-idna==3.6
-lxml==5.1.0
+caldav==1.4.0
+certifi==2024.8.30
+charset-normalizer==3.4
+idna==3.10
+lxml==5.3.0
 python-dateutil==2.9.0.post0
-requests==2.31.0
+requests==2.32.3
 six==1.16.0
-TatSu==5.11.3
-urllib3==2.2.1
-vobject==0.9.6.1
+TatSu==5.12.2
+urllib3==2.2.3
+vobject==0.9.8
+
+# patched version with timezone support, waiting for the upstream to release
+ics @ git+https://github.com/przemub/ics-py@dtstart


### PR DESCRIPTION
New environment variable, TIMEZONE, replaces timezone data received from the upstream with the timezone that we need.

This timezone data will be uploaded to the remote server.

This is required as some software generates naive timestamps in the local timezone (looking at you with contempt, Microsoft Exchange).