### PR TITLE
Switch from ics-py to icalendar library for parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 [tool.setuptools_scm]
 
 [build-system]
-requires = ["setuptools>=75.6", "setuptools-scm>=8.1"]
+requires = ["setuptools>=75.8", "setuptools-scm>=8.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -24,27 +24,27 @@ readme = "README.md"
 
 dependencies = [
     "arrow==1.3.0",
-    "attrs==24.2.0",
     "caldav==1.4.0",
-    "certifi==2024.8.30",
-    "charset-normalizer==3.4.0",
-    "click==8.1.7",
-    "icalendar==6.1.0",
-    "ics==0.8.0.dev0",  # a pre-release with added support for timezones
-    "ics_vtimezones==2020.2",
+    "certifi==2025.1.31",
+    "charset-normalizer==3.4.1",
+    "click==8.1.8",
+    "icalendar==6.1.1",
     "idna==3.10",
-    "importlib_resources==6.4.5",
     "lxml==5.3.0",
     "python-dateutil==2.9.0.post0",
-    "pytz==2024.2",
-    "recurring-ical-events==3.3.4",
+    "pytz==2025.1",
+    "recurring-ical-events==3.4.1",
     "requests==2.32.3",
     "six==1.17.0",
-    "types-python-dateutil==2.9.0.20241206",
-    "tzdata==2024.2",
-    "urllib3==2.2.3",
-    "vobject==0.9.8",
+    "tzdata==2025.1",
+    "urllib3==2.3.0",
+    "vobject==0.9.9",
     "x-wr-timezone==2.0.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "types-python-dateutil==2.9.0.20241206",
 ]
 
 [project.scripts]


### PR DESCRIPTION
As caldav library internally uses icalendar for parsing ICS, and the script itself used ics-py for the same, we effectively used two libraries for the same thing, complicating debugging of users' errors.