### PR TITLE
Add timestamps to sync output and update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
-version: "3.7"
 services:
   ics_caldav_sync:
     build:
-      context: "."
+      context: .
+    restart: unless-stopped
     env_file: ".env"
 

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -203,8 +203,9 @@ class ICSToCalDAV:
                 )
                 print("-", end="")
                 sys.stdout.flush()
-        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        print(f" [{timestamp}]")
+            if events_to_delete:
+                timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                print(f" [{timestamp}]")
 
 
 def getenv_or_raise(var):

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -162,6 +162,8 @@ class ICSToCalDAV:
         If sync_all is set, all events will be pulled. Otherwise, only
         the ones occurring after now will be.
         """
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print(f"[{timestamp}] Starting sync...", flush=True)
         now_naive = datetime.datetime.now()
         now_aware = datetime.datetime.now(datetime.timezone.utc)
         today = datetime.date.today()
@@ -188,7 +190,8 @@ class ICSToCalDAV:
                 logger.exception("Invalid event was downloaded from the remote. It will be skipped.")
             print("+", end="")
             sys.stdout.flush()
-        print()
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print(f" [{timestamp}]")
 
         if not self.keep_local:
             # Delete local events that don't exist in the remote
@@ -200,7 +203,8 @@ class ICSToCalDAV:
                 )
                 print("-", end="")
                 sys.stdout.flush()
-        print()
+        timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        print(f" [{timestamp}]")
 
 
 def getenv_or_raise(var):


### PR DESCRIPTION
Adds timestamps to sync output so you can see when syncs run, especially useful when running with Docker. Also removes the obsolete `version` field from docker-compose.yml and adds a `unless-stopped` restart policy.