### PR TITLE
No infinite overwrites

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -6,7 +6,11 @@ on:
     tags: ["*"]
 
 jobs:
+  test:
+    uses: ./.github/workflows/tests.yml
+
   build:
+    needs: test
     runs-on: ubuntu-latest
     steps:
     - name: Set up QEMU

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  pull_request:
+  workflow_call:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: pip install -e ".[dev]"
+    - name: Run tests
+      run: pytest

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Set the settings as environment variables:
 | `DEBUG`                  | boolean | No       | `false` | Set to any non-empty value to print debugging messages. Please set this when reporting an error.             |
 | `SYNC_ALL`               | boolean | No       | `false` | If set, all events in the calendar will be synced. Otherwise, only the ones occurring in the future will be. |
 | `KEEP_LOCAL`             | boolean | No       | `false` | Do not delete events on the CalDAV server that do not exist in the ICS file.                                 |
-| `IGNORED_COMPARE_FIELDS` | string  | No       | -       | When deciding if the local event is the same, ignore these fields*                                           |
+| `IGNORED_COMPARE_FIELDS` | string  | No       | -       | Fields that are ignored when checking if an event needs to be updated.*                                      |
 
 \* For Google Calendar, you can ignore DTSTAMP (changes with every download of the ICS) and SEQUENCE (reported to change randomly).
 
@@ -63,6 +63,7 @@ sync = ICSToCalDAVSync(
     # sync_all=False,
     # keep_local=False
     # timezone=None,
+    # ignored_compare_fields=[]
 )
 
 sync.synchronise()

--- a/README.md
+++ b/README.md
@@ -24,22 +24,25 @@ repository `przemub/ics_caldav_sync` tagged by short commit hashes and versions.
 
 Set the settings as environment variables:
 
-| Variable              | Type    | Required | Default | Description                                                                                                  |
-|-----------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------|
-| `REMOTE_URL`          | string  | Yes      | -       | ICS file URL. You can provide multiple URLs, separated by a space character.                                 |
-| `LOCAL_URL`           | string  | Yes      | -       | CalDAV server URL.                                                                                           |
-| `LOCAL_CALENDAR_NAME` | string  | Yes      | -       | The name of your CalDAV calendar.                                                                            |
-| `LOCAL_USERNAME`      | string  | Yes      | -       | CalDAV username.                                                                                             |
-| `LOCAL_PASSWORD`      | string  | Yes      | -       | CalDAV password.                                                                                             |
-| `LOCAL_AUTH`          | string  | No       | `basic` | CalDAV authentication method (either `basic` or `digest`).                                                   |
-| `REMOTE_USERNAME`     | string  | No       | -       | ICS host username.                                                                                           |
-| `REMOTE_PASSWORD`     | string  | No       | -       | ICS host password.                                                                                           |
-| `REMOTE_AUTH`         | string  | No       | `basic` | ICS host authentication method (either `basic` or `digest`).                                                 |
-| `TIMEZONE`            | string  | No       | -       | Override events timezone. Examples: `Utc`, `Europe/Warsaw`, `Asia/Tokyo`.                                    |
-| `SYNC_EVERY`          | string  | No       | -       | How often should the synchronisation occur? Examples: `2 minutes`, `1 hour`. Synchronise once if empty.      |
-| `DEBUG`               | boolean | No       | `false` | Set to any non-empty value to print debugging messages. Please set this when reporting an error.             |
-| `SYNC_ALL`            | boolean | No       | `false` | If set, all events in the calendar will be synced. Otherwise, only the ones occurring in the future will be. |
-| `KEEP_LOCAL`          | boolean | No       | `false` | Do not delete events on the CalDAV server that do not exist in the ICS file.                                 |
+| Variable                 | Type    | Required | Default | Description                                                                                                  |
+|--------------------------|---------|----------|---------|--------------------------------------------------------------------------------------------------------------|
+| `REMOTE_URL`             | string  | Yes      | -       | ICS file URL. You can provide multiple URLs, separated by a space character.                                 |
+| `LOCAL_URL`              | string  | Yes      | -       | CalDAV server URL.                                                                                           |
+| `LOCAL_CALENDAR_NAME`    | string  | Yes      | -       | The name of your CalDAV calendar.                                                                            |
+| `LOCAL_USERNAME`         | string  | Yes      | -       | CalDAV username.                                                                                             |
+| `LOCAL_PASSWORD`         | string  | Yes      | -       | CalDAV password.                                                                                             |
+| `LOCAL_AUTH`             | string  | No       | `basic` | CalDAV authentication method (either `basic` or `digest`).                                                   |
+| `REMOTE_USERNAME`        | string  | No       | -       | ICS host username.                                                                                           |
+| `REMOTE_PASSWORD`        | string  | No       | -       | ICS host password.                                                                                           |
+| `REMOTE_AUTH`            | string  | No       | `basic` | ICS host authentication method (either `basic` or `digest`).                                                 |
+| `TIMEZONE`               | string  | No       | -       | Override events timezone. Examples: `Utc`, `Europe/Warsaw`, `Asia/Tokyo`.                                    |
+| `SYNC_EVERY`             | string  | No       | -       | How often should the synchronisation occur? Examples: `2 minutes`, `1 hour`. Synchronise once if empty.      |
+| `DEBUG`                  | boolean | No       | `false` | Set to any non-empty value to print debugging messages. Please set this when reporting an error.             |
+| `SYNC_ALL`               | boolean | No       | `false` | If set, all events in the calendar will be synced. Otherwise, only the ones occurring in the future will be. |
+| `KEEP_LOCAL`             | boolean | No       | `false` | Do not delete events on the CalDAV server that do not exist in the ICS file.                                 |
+| `IGNORED_COMPARE_FIELDS` | string  | No       | -       | When deciding if the local event is the same, ignore these fields*                                           |
+
+\* Google sets DTSTAMP to now() which causes an infinite overwrite which can be problematic with some CALDAV servers, and SEQUENCE can also be ignored when comparing all other fields.
 
 ## Library usage
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set the settings as environment variables:
 | `KEEP_LOCAL`             | boolean | No       | `false` | Do not delete events on the CalDAV server that do not exist in the ICS file.                                 |
 | `IGNORED_COMPARE_FIELDS` | string  | No       | -       | When deciding if the local event is the same, ignore these fields*                                           |
 
-\* Google sets DTSTAMP to now() which causes an infinite overwrite which can be problematic with some CALDAV servers, and SEQUENCE can also be ignored when comparing all other fields.
+\* For Google Calendar, you can ignore DTSTAMP (changes with every download of the ICS) and SEQUENCE (reported to change randomly).
 
 ## Library usage
 
@@ -123,6 +123,7 @@ services:
 On the local side (CalDAV server):
 - [Baïkal](https://sabre.io/baikal/)
 - [Radicale](https://radicale.org/v3.html)
+- [xandikos](https://www.xandikos.org/)
 
 On the remote site (ICS file generator):
 - [Google Calendar](https://support.google.com/calendar/answer/37083)

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -6,6 +6,7 @@ import os
 import pathlib
 import sys
 import time
+from copy import copy
 from typing import Literal
 
 import arrow
@@ -17,6 +18,7 @@ import requests
 import requests.auth
 import vobject.base
 import x_wr_timezone
+
 
 logger = logging.getLogger(__name__)
 AuthenticationMethod = Literal["basic", "digest"]
@@ -59,7 +61,7 @@ class ICSToCalDAV:
         sync_all: bool = False,
         keep_local: bool = False,
         timezone: str | None = None,
-        ignored_compare_fields: str,
+        ignored_compare_fields: str | None = None,
     ):
         self.timezone = dateutil.tz.gettz(timezone) \
             if timezone is not None else None
@@ -92,7 +94,7 @@ class ICSToCalDAV:
         self.sync_all = sync_all
         self.keep_local = keep_local
 
-        self.ignored_compare_fields = ignored_compare_fields
+        self.ignored_compare_fields = ignored_compare_fields.split(" ") if ignored_compare_fields else []
 
     @staticmethod
     def _get_auth(username: str, password: str, method: AuthenticationMethod) -> requests.auth.AuthBase:
@@ -135,36 +137,21 @@ class ICSToCalDAV:
         )
         return local_events_ids
 
-
-    def _compare(self, fromlocal, fromremote) -> bool:
+    def _compare(
+        self,
+        local_event: icalendar.Component,
+        remote_event: icalendar.Component
+    ) -> bool:
         """
-        Compares a remote ics event with a local ical event
+        Compares two icalendar.Component objects, respecting ignored_compare_fields setting.
         """
-        ignoredfields = []
-        if self.ignored_compare_fields != None:
-            ignoredfields = self.ignored_compare_fields.split(" ")
-        def veventfromcal(vcal: icalendar.Calendar):
-            for component in vcal._icalendar_instance.subcomponents:
-                if isinstance(component, icalendar.cal.Event):
-                    return component
+        local_event = copy(local_event)
+        remote_event = copy(remote_event)
+        for field in self.ignored_compare_fields:
+            local_event.pop(field, None)
+            remote_event.pop(field, None)
 
-        local = veventfromcal(fromlocal)
-        logger.debug(local.keys())
-        logger.debug(fromremote.keys())
-        if not len(local.keys()) == len(fromremote.keys()):
-            return False
-        # go both ways in case there's the same number but different keys!
-        for key in local.keys():
-            if key not in ignoredfields:
-                if not local[key] == fromremote[key]:
-                    logger.debug("`%s`: `%s` != `%s`!",key,local[key],fromremote[key])
-                    return False
-        for key in fromremote.keys():
-            if key not in ignoredfields:
-                if not local[key] == fromremote[key]:
-                    logger.debug("`%s`: `%s` != `%s`!",key,local[key],fromremote[key])
-                    return False
-        return True
+        return local_event == remote_event
 
     @staticmethod
     def _wrap(vevent: icalendar.Event) -> bytes:
@@ -182,7 +169,7 @@ class ICSToCalDAV:
         calendar.add_missing_timezones()
 
         data = calendar.to_ical()
-#        logger.debug("Serialized event:\n%s", data)
+        logger.debug("Serialized event:\n%s", data)
 
         return data
 
@@ -218,17 +205,18 @@ class ICSToCalDAV:
                     if now_naive > end:
                         continue
 
+            # If the event already exists and is what we would write, skip.
             try:
-                # If the event already exists and is what we would write, skip.
-                local_event_to_find = self.local_calendar.event_by_uid(remote_event.uid)
-                if local_event_to_find is not None:
-                    if self._compare(local_event_to_find, remote_event):
-                        logger.debug("Skipping event [%s] as it is identical",remote_event.uid)
-                    else:
-                        self.local_calendar.save_event(self._wrap(remote_event))
-                else:
-                    self.local_calendar.save_event(self._wrap(remote_event))
+                local_event = self.local_calendar.get_event_by_uid(remote_event.uid).icalendar_component
+                if self._compare(local_event, remote_event):
+                    logger.debug("Skipping event [%s] as it is identical", remote_event.uid)
+                    continue
+            except caldav.lib.error.NotFoundError:
+                pass
 
+            # All checks passed, save the event
+            try:
+                self.local_calendar.save_event(self._wrap(remote_event))
             except vobject.base.ValidateError:
                 logger.exception("Invalid event was downloaded from the remote. It will be skipped.")
             print("+", end="")
@@ -249,6 +237,7 @@ class ICSToCalDAV:
             if events_to_delete:
                 timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 print(f" [{timestamp}]")
+
 
 def getenv_or_raise(var):
     if (value := os.getenv(var)) is None:

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -44,6 +44,7 @@ class ICSToCalDAV:
     * sync_all (bool, optional): Sync past events.
     * keep_local (bool, optional): Do not delete events on the CalDAV server that do not exist in the ICS file.
     * timezone (str, optional): Override events timezone. See: https://dateutil.readthedocs.io/en/stable/tz.html
+    * ignored_compare_fields(str, optional): Fields that are ignored when checking if an event needs to be updated.
     """
 
     def __init__(

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -17,6 +17,7 @@ import requests.auth
 import vobject.base
 import x_wr_timezone
 
+import pprint
 
 logger = logging.getLogger(__name__)
 AuthenticationMethod = Literal["basic", "digest"]
@@ -132,6 +133,21 @@ class ICSToCalDAV:
         )
         return local_events_ids
 
+
+    @staticmethod
+    def _compare(fromlocal, fromremote) -> bool:
+        """
+        Compares a remote ics event with a local ical event
+        Currently just checks uid, that's not good enough, but is for tonight
+        """
+        def veventfromcal(vcal: icalendar.Calendar):
+            for component in vcal._icalendar_instance.subcomponents:
+                if isinstance(component, icalendar.cal.Event):
+                    return component
+
+        local = veventfromcal(fromlocal)
+        return local.uid == fromremote.uid
+
     @staticmethod
     def _wrap(vevent: icalendar.Event) -> bytes:
         """
@@ -148,7 +164,7 @@ class ICSToCalDAV:
         calendar.add_missing_timezones()
 
         data = calendar.to_ical()
-        logger.debug("Serialized event:\n%s", data)
+#        logger.debug("Serialized event:\n%s", data)
 
         return data
 
@@ -185,7 +201,18 @@ class ICSToCalDAV:
                         continue
 
             try:
-                self.local_calendar.save_event(self._wrap(remote_event))
+                # If the event already exists and is what we would write, skip.
+                local_event_to_find = self.local_calendar.event_by_uid(remote_event.uid)
+                if local_event_to_find is not None:
+
+
+                    if self._compare(local_event_to_find, remote_event):
+                        logger.debug("Skipping event [%s] as it is identical",remote_event.uid)
+                    else:
+                        self.local_calendar.save_event(self._wrap(remote_event))
+                else:
+                    self.local_calendar.save_event(self._wrap(remote_event))
+
             except vobject.base.ValidateError:
                 logger.exception("Invalid event was downloaded from the remote. It will be skipped.")
             print("+", end="")
@@ -206,7 +233,6 @@ class ICSToCalDAV:
             if events_to_delete:
                 timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
                 print(f" [{timestamp}]")
-
 
 def getenv_or_raise(var):
     if (value := os.getenv(var)) is None:

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -60,6 +60,7 @@ class ICSToCalDAV:
         sync_all: bool = False,
         keep_local: bool = False,
         timezone: str | None = None,
+        ignored_compare_fields: str,
     ):
         self.timezone = dateutil.tz.gettz(timezone) \
             if timezone is not None else None
@@ -91,6 +92,8 @@ class ICSToCalDAV:
 
         self.sync_all = sync_all
         self.keep_local = keep_local
+
+        self.ignored_compare_fields = ignored_compare_fields
 
     @staticmethod
     def _get_auth(username: str, password: str, method: AuthenticationMethod) -> requests.auth.AuthBase:
@@ -134,19 +137,35 @@ class ICSToCalDAV:
         return local_events_ids
 
 
-    @staticmethod
-    def _compare(fromlocal, fromremote) -> bool:
+    def _compare(self, fromlocal, fromremote) -> bool:
         """
         Compares a remote ics event with a local ical event
-        Currently just checks uid, that's not good enough, but is for tonight
         """
+        ignoredfields = []
+        if self.ignored_compare_fields != None:
+            ignoredfields = self.ignored_compare_fields.split(" ")
         def veventfromcal(vcal: icalendar.Calendar):
             for component in vcal._icalendar_instance.subcomponents:
                 if isinstance(component, icalendar.cal.Event):
                     return component
 
         local = veventfromcal(fromlocal)
-        return local.uid == fromremote.uid
+        logger.debug(local.keys())
+        logger.debug(fromremote.keys())
+        if not len(local.keys()) == len(fromremote.keys()):
+            return False
+        # go both ways in case there's the same number but different keys!
+        for key in local.keys():
+            if key not in ignoredfields:
+                if not local[key] == fromremote[key]:
+                    logger.debug("`%s`: `%s` != `%s`!",key,local[key],fromremote[key])
+                    return False
+        for key in fromremote.keys():
+            if key not in ignoredfields:
+                if not local[key] == fromremote[key]:
+                    logger.debug("`%s`: `%s` != `%s`!",key,local[key],fromremote[key])
+                    return False
+        return True
 
     @staticmethod
     def _wrap(vevent: icalendar.Event) -> bytes:
@@ -204,8 +223,6 @@ class ICSToCalDAV:
                 # If the event already exists and is what we would write, skip.
                 local_event_to_find = self.local_calendar.event_by_uid(remote_event.uid)
                 if local_event_to_find is not None:
-
-
                     if self._compare(local_event_to_find, remote_event):
                         logger.debug("Skipping event [%s] as it is identical",remote_event.uid)
                     else:
@@ -262,6 +279,7 @@ def main():
         "sync_all": bool(os.getenv("SYNC_ALL", False)),
         "keep_local": bool(os.getenv("KEEP_LOCAL", False)),
         "timezone": os.getenv("TIMEZONE") or None,
+        "ignored_compare_fields": os.getenv("IGNORED_COMPARE_FIELDS") or None,
     }
 
     sync_every = os.getenv("SYNC_EVERY", None)

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -17,8 +17,6 @@ import requests.auth
 import vobject.base
 import x_wr_timezone
 
-import pprint
-
 logger = logging.getLogger(__name__)
 AuthenticationMethod = Literal["basic", "digest"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "black==26.3.0",
     "build==1.4.0",
     "licensecheck==2025.1.0",
+    "pytest==9.0.2",
     "types-python-dateutil==2.9.0.20260305",
     "twine==6.2.0",
     "vermin==1.8.0"

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,84 @@
+from datetime import datetime
+
+import icalendar
+import pytest
+
+from ics_caldav_sync import ICSToCalDAV
+
+
+def make_event(**props) -> icalendar.Event:
+    event = icalendar.Event()
+    for k, v in props.items():
+        event.add(k, v)
+    return event
+
+
+@pytest.fixture()
+def comparator():
+    """A minimal ICSToCalDAV-like object with just the _compare method and ignored_compare_fields."""
+    obj = object.__new__(ICSToCalDAV)
+    obj.ignored_compare_fields = []
+    return obj
+
+
+class TestCompareIdentical:
+    def test_identical_events(self, comparator):
+        a = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 12))
+        b = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 12))
+        assert comparator._compare(a, b)
+
+    def test_empty_events(self, comparator):
+        assert comparator._compare(icalendar.Event(), icalendar.Event())
+
+
+class TestCompareDifferent:
+    def test_different_summary(self, comparator):
+        a = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 12))
+        b = make_event(summary="Lunch", dtstart=datetime(2025, 1, 1, 12))
+        assert not comparator._compare(a, b)
+
+    def test_different_start(self, comparator):
+        a = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 12))
+        b = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 14))
+        assert not comparator._compare(a, b)
+
+    def test_extra_field(self, comparator):
+        a = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 12))
+        b = make_event(summary="Meeting", dtstart=datetime(2025, 1, 1, 12), location="Room 1")
+        assert not comparator._compare(a, b)
+
+
+class TestCompareIgnoredFields:
+    def test_ignored_field_makes_different_events_equal(self, comparator):
+        comparator.ignored_compare_fields = ["DTSTAMP"]
+        a = make_event(summary="Meeting", dtstamp=datetime(2025, 1, 1, 10))
+        b = make_event(summary="Meeting", dtstamp=datetime(2025, 6, 1, 10))
+        assert comparator._compare(a, b)
+
+    def test_ignored_field_missing_from_one_event(self, comparator):
+        comparator.ignored_compare_fields = ["DTSTAMP"]
+        a = make_event(summary="Meeting", dtstamp=datetime(2025, 1, 1, 10))
+        b = make_event(summary="Meeting")
+        assert comparator._compare(a, b)
+
+    def test_multiple_ignored_fields(self, comparator):
+        comparator.ignored_compare_fields = ["DTSTAMP", "SEQUENCE"]
+        a = make_event(summary="Meeting", dtstamp=datetime(2025, 1, 1), sequence=1)
+        b = make_event(summary="Meeting", dtstamp=datetime(2025, 6, 1), sequence=5)
+        assert comparator._compare(a, b)
+
+    def test_still_differs_on_non_ignored_field(self, comparator):
+        comparator.ignored_compare_fields = ["DTSTAMP"]
+        a = make_event(summary="Meeting", dtstamp=datetime(2025, 1, 1))
+        b = make_event(summary="Lunch", dtstamp=datetime(2025, 1, 1))
+        assert not comparator._compare(a, b)
+
+
+class TestCompareDoesNotMutate:
+    def test_originals_unchanged(self, comparator):
+        comparator.ignored_compare_fields = ["DTSTAMP"]
+        a = make_event(summary="Meeting", dtstamp=datetime(2025, 1, 1))
+        b = make_event(summary="Meeting", dtstamp=datetime(2025, 6, 1))
+        comparator._compare(a, b)
+        assert "DTSTAMP" in a
+        assert "DTSTAMP" in b

--- a/tests/test_synchronise.py
+++ b/tests/test_synchronise.py
@@ -1,0 +1,81 @@
+from datetime import datetime
+from unittest.mock import MagicMock, PropertyMock
+
+import caldav.lib.error
+import icalendar
+import pytest
+
+from ics_caldav_sync import ICSToCalDAV
+
+
+def make_event(**props) -> icalendar.Event:
+    event = icalendar.Event()
+    for k, v in props.items():
+        event.add(k, v)
+    return event
+
+
+@pytest.fixture()
+def syncer():
+    obj = object.__new__(ICSToCalDAV)
+    obj.ignored_compare_fields = []
+    obj.sync_all = True
+    obj.keep_local = True
+    obj.local_calendar = MagicMock()
+    obj.local_client = MagicMock()
+    obj.remote_calendar = MagicMock()
+    return obj
+
+
+class TestSynchroniseUsesCompare:
+    def test_skips_identical_event(self, syncer):
+        event = make_event(summary="Meeting", uid="123", dtstamp=datetime(2025, 1, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[event])
+        syncer.local_calendar.get_event_by_uid.return_value.icalendar_component = event
+
+        syncer.synchronise()
+
+        syncer.local_calendar.save_event.assert_not_called()
+
+    def test_saves_new_event(self, syncer):
+        event = make_event(summary="Meeting", uid="123", dtstamp=datetime(2025, 1, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[event])
+        syncer.local_calendar.get_event_by_uid.side_effect = caldav.lib.error.NotFoundError
+
+        syncer.synchronise()
+
+        syncer.local_calendar.save_event.assert_called_once()
+
+    def test_saves_changed_event(self, syncer):
+        remote = make_event(summary="Updated", uid="123", dtstamp=datetime(2025, 1, 1))
+        local = make_event(summary="Original", uid="123", dtstamp=datetime(2025, 1, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[remote])
+        syncer.local_calendar.get_event_by_uid.return_value.icalendar_component = local
+
+        syncer.synchronise()
+
+        syncer.local_calendar.save_event.assert_called_once()
+
+    def test_skips_with_ignored_fields(self, syncer):
+        """Events that differ only in ignored fields should be skipped."""
+        syncer.ignored_compare_fields = ["DTSTAMP"]
+        a = make_event(summary="Meeting", uid="123", dtstamp=datetime(2025, 1, 1))
+        b = make_event(summary="Meeting", uid="123", dtstamp=datetime(2025, 6, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[a])
+        syncer.local_calendar.get_event_by_uid.return_value.icalendar_component = b
+
+        syncer.synchronise()
+
+        syncer.local_calendar.save_event.assert_not_called()
+
+    def test_saves_when_ignored_fields_not_only_difference(self, syncer):
+        """Events that differ on non-ignored fields should still be saved."""
+        syncer.ignored_compare_fields = ["DTSTAMP"]
+        remote = make_event(summary="Updated", uid="123", dtstamp=datetime(2025, 1, 1))
+        local = make_event(summary="Original", uid="123", dtstamp=datetime(2025, 6, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[remote])
+        syncer.local_calendar.get_event_by_uid.return_value.icalendar_component = local
+
+        syncer.synchronise()
+
+        syncer.local_calendar.save_event.assert_called_once()


### PR DESCRIPTION
As mentioned in  #17 , this PR allows for checking that there isn't an already existing item on the local side, instead of just pushing and hoping the caldav server will deal with it for us.

It also adds the ability to exclude fields from the comparison because google is playing awkward with the DTSTAMP field constantly changing and the SEQUENCE field is also sometimes changing with no other change visible.

Fixes: #17 