### PR TITLE
handle NoInstancesException and recurrence events

### DIFF
--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -168,8 +168,9 @@ class ICSToCalDAV:
         now_naive = datetime.datetime.now()
         now_aware = datetime.datetime.now(datetime.timezone.utc)
         today = datetime.date.today()
-
-        for remote_event in self.remote_calendar.events:
+    
+        sorted_remote_events = sorted(self.remote_calendar.events, key=lambda event: event.get("RECURRENCE-ID") is not None)
+        for remote_event in sorted_remote_events:
             # Skip events in the past, unless requested not to.
             if not self.sync_all:
                 end = remote_event.end
@@ -189,6 +190,11 @@ class ICSToCalDAV:
                 self.local_calendar.save_event(self._wrap(remote_event))
             except vobject.base.ValidateError:
                 logger.exception("Invalid event was downloaded from the remote. It will be skipped.")
+            except caldav.lib.error.PutError as e:
+                if "NoInstancesException" in str(e):
+                    logger.warning("Skipping event with no valid recurrence instances: %s", remote_event.get("UID"))
+                else:
+                    raise
             print("+", end="")
             sys.stdout.flush()
         timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/ics_caldav_sync.py
+++ b/ics_caldav_sync.py
@@ -196,8 +196,15 @@ class ICSToCalDAV:
         now_naive = datetime.datetime.now()
         now_aware = datetime.datetime.now(datetime.timezone.utc)
         today = datetime.date.today()
-    
-        sorted_remote_events = sorted(self.remote_calendar.events, key=lambda event: event.get("RECURRENCE-ID") is not None)
+
+        # ICS files give no ordering guarantee, but a recurrence override
+        # (an event with RECURRENCE-ID) can only be saved after its parent
+        # recurring event exists locally. Sort so parents come first; the
+        # sort is stable, so the original order is otherwise preserved.
+        sorted_remote_events = sorted(
+            self.remote_calendar.events,
+            key=lambda event: event.get("RECURRENCE-ID") is not None,
+        )
         for remote_event in sorted_remote_events:
             # Skip events in the past, unless requested not to.
             if not self.sync_all:
@@ -229,8 +236,14 @@ class ICSToCalDAV:
             except vobject.base.ValidateError:
                 logger.exception("Invalid event was downloaded from the remote. It will be skipped.")
             except caldav.lib.error.PutError as e:
+                # An event whose recurrence rule yields zero occurrences is
+                # valid per RFC 5545 but rejected by sabre/dav-based servers
+                # (Baikal, Nextcloud). caldav has no typed exception for this,
+                # so we match on the sabre exception class name that the server
+                # echoes back in the response body. This is server-dependent
+                # and may not catch the same condition on non-sabre servers.
                 if "NoInstancesException" in str(e):
-                    logger.warning("Skipping event with no valid recurrence instances: %s", remote_event.get("UID"))
+                    logger.warning("Skipping event with no valid recurrence instances: %s", remote_event.uid)
                 else:
                     raise
             print("+", end="")

--- a/tests/test_synchronise.py
+++ b/tests/test_synchronise.py
@@ -79,3 +79,50 @@ class TestSynchroniseUsesCompare:
         syncer.synchronise()
 
         syncer.local_calendar.save_event.assert_called_once()
+
+
+class TestSynchroniseOrdersRecurrence:
+    def test_parent_saved_before_recurrence_override(self, syncer):
+        """A recurrence override (RECURRENCE-ID) must be saved after its
+        parent, even when the ICS lists it first."""
+        parent = make_event(summary="Parent", uid="123", dtstamp=datetime(2025, 1, 1))
+        override = make_event(summary="Override", uid="123", dtstamp=datetime(2025, 1, 1))
+        override.add("RECURRENCE-ID", datetime(2025, 1, 2))
+        # Deliberately out of order: override first.
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[override, parent])
+        syncer.local_calendar.get_event_by_uid.side_effect = caldav.lib.error.NotFoundError
+
+        syncer.synchronise()
+
+        saved = [call.args[0] for call in syncer.local_calendar.save_event.call_args_list]
+        assert len(saved) == 2
+        assert b"RECURRENCE-ID" not in saved[0]
+        assert b"RECURRENCE-ID" in saved[1]
+
+
+class TestSynchroniseHandlesPutError:
+    def test_skips_event_with_no_recurrence_instances(self, syncer):
+        """A sabre/dav NoInstancesException is logged and skipped, not fatal."""
+        event = make_event(summary="Empty rule", uid="123", dtstamp=datetime(2025, 1, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[event])
+        syncer.local_calendar.get_event_by_uid.side_effect = caldav.lib.error.NotFoundError
+        syncer.local_calendar.save_event.side_effect = caldav.lib.error.PutError(
+            "400 Bad Request\n\n<s:exception>Sabre\\VObject\\Recur\\NoInstancesException</s:exception>"
+        )
+
+        # Should not raise.
+        syncer.synchronise()
+
+        syncer.local_calendar.save_event.assert_called_once()
+
+    def test_other_put_errors_propagate(self, syncer):
+        """A PutError that is not a NoInstancesException must still be fatal."""
+        event = make_event(summary="Meeting", uid="123", dtstamp=datetime(2025, 1, 1))
+        type(syncer.remote_calendar).events = PropertyMock(return_value=[event])
+        syncer.local_calendar.get_event_by_uid.side_effect = caldav.lib.error.NotFoundError
+        syncer.local_calendar.save_event.side_effect = caldav.lib.error.PutError(
+            "403 Forbidden\n\nPermission denied"
+        )
+
+        with pytest.raises(caldav.lib.error.PutError):
+            syncer.synchronise()


### PR DESCRIPTION
When syncing an ics, especially those from Google Calendar, there sometimes is an faulty event that has 0 instances (for example "once every week, for the next 6 days, except the first day" meaning there's no actual occurrence of the event and it's invisible to the user, technically valid per RFC 5545, however, rejected by sabre/dav based servers, such as Baikal and Nextcloud), this normally would kill off the entire syncing process, but it seems better to me to only log a warning instead as these events have no use case being saved.

Also resolved the 'Could not find parent recurring event' error caused by specific instanced of recurrence events being handled before the original recurrence event being handled, as there's no guarantee the events in an ICS file are sorted.